### PR TITLE
Feature/conda based travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,14 @@ before_install:
 install:
   - conda create -q -n ding0_env python=$PYTHON_VERSION
   - conda env update -q -n ding0_env --file=ding0_test_env.yml
-  - conda info -a
   - source activate ding0_env
   - EGOIOCONFIGDIR=`python -c "import os; print(os.path.join(os.path.expanduser(\"~\"), \".egoio\"))"`
   - mkdir $EGOIOCONFIGDIR
   - printf '%s\n' '[oedb]' 'dialect = oedialect' 'host = openenergy-platform.org' 'port = 443' 'database = oedb' 'username = Ding0_test_user' 'password = 659193bb5925d401943e4f77d4bac7479bcd9214'> $EGOIOCONFIGDIR/config.ini
   - cat $EGOIOCONFIGDIR/config.ini
   - pip install --no-cache-dir .
+  - conda list
+  - pip list
 # command to run tests
 script:
   - pytest -vv

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
 install:
   - conda create -q -n ding0_env python=$PYTHON_VERSION
   - conda env update -q -n ding0_env --file=ding0_test_env.yml
-  - conda init $SHELL
+  - conda init bash
   - conda info -a
   - conda activate ding0_env
   - EGOIOCONFIGDIR=`python -c "import os; print(os.path.join(os.path.expanduser(\"~\"), \".egoio\"))"`

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,8 @@ before_install:
 install:
   - conda create -q -n ding0_env python=$PYTHON_VERSION
   - conda env update -q -n ding0_env --file=ding0_test_env.yml
-  - conda init bash
   - conda info -a
-  - conda activate ding0_env
+  - source activate ding0_env
   - EGOIOCONFIGDIR=`python -c "import os; print(os.path.join(os.path.expanduser(\"~\"), \".egoio\"))"`
   - mkdir $EGOIOCONFIGDIR
   - printf '%s\n' '[oedb]' 'dialect = oedialect' 'host = openenergy-platform.org' 'port = 443' 'database = oedb' 'username = Ding0_test_user' 'password = 659193bb5925d401943e4f77d4bac7479bcd9214'> $EGOIOCONFIGDIR/config.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
 install:
   - conda create -n ding0_env python=$PYTHON_VERSION
   - echo "python == $PYTHON_VERSION" >> $HOME/miniconda/envs/ding0_env/pinned
-  - conda env update -n ding0_env --freeze-installed --file=ding0_test_env.yml
+  - conda env update -n ding0_env --file=ding0_test_env.yml
   - source activate ding0_env
   - EGOIOCONFIGDIR=`python -c "import os; print(os.path.join(os.path.expanduser(\"~\"), \".egoio\"))"`
   - mkdir $EGOIOCONFIGDIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,37 @@
+# Modified from
+# https://github.com/PyPSA/PyPSA/blob/master/.travis.yml
+
+dist: xenial
 language: python
-python:
-  - "3.4"
-  - "3.5"
-  - "3.6"
-  # - "3.7"
-# command to install dependencies
+sudo: false # use container based infrastructure
+matrix:
+  include:
+    - env:
+        - PYTHON_VERSION="3.4"
+    - env:
+        - PYTHON_VERSION="3.5"
+    - env:
+        - PYTHON_VERSION="3.6"
+    - env:
+        - PYTHON_VERSION="3.7"
+before_install:
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  # Useful for debugging any issues with conda
+  - conda info -a
 install:
+  - conda create -q -n ding0_env python=$PYTHON_VERSION
+  - conda env update -q -n ding0_env --file=requirements.yml
+  - conda activate ding0_env
   - EGOIOCONFIGDIR=`python -c "import os; print(os.path.join(os.path.expanduser(\"~\"), \".egoio\"))"`
   - mkdir $EGOIOCONFIGDIR
   - printf '%s\n' '[oedb]' 'dialect = oedialect' 'host = openenergy-platform.org' 'port = 443' 'database = oedb' 'username = Ding0_test_user' 'password = 659193bb5925d401943e4f77d4bac7479bcd9214'> $EGOIOCONFIGDIR/config.ini
   - cat $EGOIOCONFIGDIR/config.ini
-  - pip install -r requirements.txt
+  - pip install --no-cache-dir .
 # command to run tests
 script:
   - pytest -vv

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,7 @@ before_install:
   # Useful for debugging any issues with conda
   - conda info -a
 install:
-  - conda create -q -n ding0_env python=$PYTHON_VERSION
-  - conda env update -q -n ding0_env --file=ding0_test_env.yml
+  - conda env create -q -n ding0_env python=$PYTHON_VERSION --file=ding0_test_env.yml
   - source activate ding0_env
   - EGOIOCONFIGDIR=`python -c "import os; print(os.path.join(os.path.expanduser(\"~\"), \".egoio\"))"`
   - mkdir $EGOIOCONFIGDIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,9 @@ before_install:
   # Useful for debugging any issues with conda
   - conda info -a
 install:
-  - conda env create -q -n ding0_env python=$PYTHON_VERSION --file=ding0_test_env.yml
+  - conda create -n ding0_env python=$PYTHON_VERSION
+  - echo "python == $PYTHON_VERSION" >> $HOME/miniconda/envs/ding0_env/pinned
+  - conda env update -n ding0_env --freeze-installed --file=ding0_test_env.yml
   - source activate ding0_env
   - EGOIOCONFIGDIR=`python -c "import os; print(os.path.join(os.path.expanduser(\"~\"), \".egoio\"))"`
   - mkdir $EGOIOCONFIGDIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
   - conda info -a
 install:
   - conda create -q -n ding0_env python=$PYTHON_VERSION
-  - conda env update -q -n ding0_env --file=requirements.yml
+  - conda env update -q -n ding0_env --file=ding0_test_env.yml
   - conda activate ding0_env
   - EGOIOCONFIGDIR=`python -c "import os; print(os.path.join(os.path.expanduser(\"~\"), \".egoio\"))"`
   - mkdir $EGOIOCONFIGDIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ before_install:
 install:
   - conda create -q -n ding0_env python=$PYTHON_VERSION
   - conda env update -q -n ding0_env --file=ding0_test_env.yml
+  - conda init $SHELL
+  - conda info -a
   - conda activate ding0_env
   - EGOIOCONFIGDIR=`python -c "import os; print(os.path.join(os.path.expanduser(\"~\"), \".egoio\"))"`
   - mkdir $EGOIOCONFIGDIR

--- a/ding0/core/network/grids.py
+++ b/ding0/core/network/grids.py
@@ -551,7 +551,7 @@ class MVGridDing0(GridDing0):
         References
         ----------
         .. [#] Klaus Heuck et al., "Elektrische Energieversorgung", Vieweg+Teubner, Wiesbaden, 2007
-        .. [#] René Flosdorff et al., "Elektrische Energieverteilung", Vieweg+Teubner, 2005
+        .. [#] Rene Flosdorff et al., "Elektrische Energieverteilung", Vieweg+Teubner, 2005
         .. [#] Suedkabel GmbH, "Einadrige VPE-isolierte Mittelspannungskabel",
             http://www.suedkabel.de/cms/upload/pdf/Garnituren/Einadrige_VPE-isolierte_Mittelspannungskabel.pdf, 2017
         .. [#] Deutsche Energie-Agentur GmbH (dena), "dena-Verteilnetzstudie. Ausbau- und Innovationsbedarf der

--- a/ding0/core/network/grids.py
+++ b/ding0/core/network/grids.py
@@ -460,8 +460,8 @@ class MVGridDing0(GridDing0):
 
         References
         ----------
-        .. [#] Falk Schaller et al., "Modellierung realitätsnaher zukünftiger Referenznetze im Verteilnetzsektor zur
-            Überprüfung der Elektroenergiequalität", Internationaler ETG-Kongress Würzburg, 2011
+        .. [#] Falk Schaller et al., "Modellierung realitaetsnaher zukuenftiger Referenznetze im Verteilnetzsektor zur
+            Ueberpruefung der Elektroenergiequalitaet", Internationaler ETG-Kongress Wuerzburg, 2011
         .. [#] Klaus Heuck et al., "Elektrische Energieversorgung", Vieweg+Teubner, Wiesbaden, 2007
 
         """
@@ -552,7 +552,7 @@ class MVGridDing0(GridDing0):
         ----------
         .. [#] Klaus Heuck et al., "Elektrische Energieversorgung", Vieweg+Teubner, Wiesbaden, 2007
         .. [#] René Flosdorff et al., "Elektrische Energieverteilung", Vieweg+Teubner, 2005
-        .. [#] Südkabel GmbH, "Einadrige VPE-isolierte Mittelspannungskabel",
+        .. [#] Suedkabel GmbH, "Einadrige VPE-isolierte Mittelspannungskabel",
             http://www.suedkabel.de/cms/upload/pdf/Garnituren/Einadrige_VPE-isolierte_Mittelspannungskabel.pdf, 2017
         .. [#] Deutsche Energie-Agentur GmbH (dena), "dena-Verteilnetzstudie. Ausbau- und Innovationsbedarf der
             Stromverteilnetze in Deutschland bis 2030.", 2012

--- a/ding0/flexopt/check_tech_constraints.py
+++ b/ding0/flexopt/check_tech_constraints.py
@@ -392,7 +392,7 @@ def get_critical_voltage_at_nodes(grid):
     References
     ----------
     .. [#VDE] VDE Anwenderrichtlinie: Erzeugungsanlagen am Niederspannungsnetz –
-        Technische Mindestanforderungen für Anschluss und Parallelbetrieb von
+        Technische Mindestanforderungen fuer Anschluss und Parallelbetrieb von
         Erzeugungsanlagen am Niederspannungsnetz, 2011
     """
 
@@ -555,7 +555,7 @@ def voltage_delta_vde(v_nom, s_max, r, x, cos_phi):
     References
     ----------
     .. [#] VDE Anwenderrichtlinie: Erzeugungsanlagen am Niederspannungsnetz –
-        Technische Mindestanforderungen für Anschluss und Parallelbetrieb von
+        Technische Mindestanforderungen fuer Anschluss und Parallelbetrieb von
         Erzeugungsanlagen am Niederspannungsnetz, 2011
 
     """

--- a/ding0/flexopt/reinforce_grid.py
+++ b/ding0/flexopt/reinforce_grid.py
@@ -49,7 +49,7 @@ def reinforce_grid(grid, mode):
     .. [DENA] Deutsche Energie-Agentur GmbH (dena), "dena-Verteilnetzstudie. Ausbau- und Innovationsbedarf der
             Stromverteilnetze in Deutschland bis 2030.", 2012
     .. [VNSRP] Ackermann, T., Untsch, S., Koch, M., & Rothfuchs, H. (2014).
-            Verteilnetzstudie Rheinland-Pfalz. Hg. v. Ministerium für
+            Verteilnetzstudie Rheinland-Pfalz. Hg. v. Ministerium fuer
             Wirtschaft, Klimaschutz, Energie und Landesplanung Rheinland-Pfalz
             (MWKEL). energynautics GmbH.
 

--- a/ding0/grid/mv_grid/models/models.py
+++ b/ding0/grid/mv_grid/models/models.py
@@ -348,8 +348,8 @@ class Route(object):
         .. [#] M. Sakulin, W. Hipp, "Netzaspekte von dezentralen Erzeugungseinheiten,
             Studie im Auftrag der E-Control GmbH", TU Graz, 2004
         .. [#] Klaus Heuck et al., "Elektrische Energieversorgung", Vieweg+Teubner, Wiesbaden, 2007
-        .. [#] FGH e.V.: "Technischer Bericht 302: Ein Werkzeug zur Optimierung der Störungsbeseitigung
-            für Planung und Betrieb von Mittelspannungsnetzen", Tech. rep., 2008
+        .. [#] FGH e.V.: "Technischer Bericht 302: Ein Werkzeug zur Optimierung der Stoerungsbeseitigung
+            fuer Planung und Betrieb von Mittelspannungsnetzen", Tech. rep., 2008
         """
 
         # load parameters

--- a/ding0/grid/mv_grid/mv_routing.py
+++ b/ding0/grid/mv_grid/mv_routing.py
@@ -114,8 +114,8 @@ def routing_solution_to_ding0_graph(graph, solution):
     :networkx:`NetworkX Graph Obj< >` 
         NetworkX graph object with nodes and edges
     """
-    # TODO: Bisherige Herangehensweise (diese Funktion): Branches werden nach Routing erstellt um die Funktionsfähigkeit
-    # TODO: des Routing-Tools auch für die TestCases zu erhalten. Es wird ggf. notwendig, diese direkt im Routing vorzunehmen.
+    # TODO: Bisherige Herangehensweise (diese Funktion): Branches werden nach Routing erstellt um die Funktionsfaehigkeit
+    # TODO: des Routing-Tools auch fuer die TestCases zu erhalten. Es wird ggf. notwendig, diese direkt im Routing vorzunehmen.
 
     # build node dict (name: obj) from graph nodes to map node names on node objects
     node_list = {str(n): n for n in graph.nodes()}

--- a/ding0/grid/mv_grid/solvers/local_search.py
+++ b/ding0/grid/mv_grid/solvers/local_search.py
@@ -99,8 +99,8 @@ class LocalSearchSolver(BaseSolver):
     References
     ----------
     .. [#] W. Wenger, "Multikriterielle Tourenplanung", Dissertation, 2009
-    .. [#] M. Kämpf, "Probleme der Tourenbildung", Chemnitzer Informatik-Berichte, 2006
-    .. [#] O. Bräysy, M. Gendreau, "Vehicle Routing Problem with Time Windows,
+    .. [#] M. Kaempf, "Probleme der Tourenbildung", Chemnitzer Informatik-Berichte, 2006
+    .. [#] O. Braeysy, M. Gendreau, "Vehicle Routing Problem with Time Windows,
         Part I: Route Construction and Local Search Algorithms",
         Transportation Science, vol. 39, Issue 1, pp. 104-118, 2005
     .. [#] C. Boomgaarden, "Dynamische Tourenplanung und -steuerung",

--- a/ding0/grid/mv_grid/tools.py
+++ b/ding0/grid/mv_grid/tools.py
@@ -57,8 +57,8 @@ def set_circuit_breakers(mv_grid, mode='load', debug=False):
     References
     ----------
     .. [#] X. Tao, "Automatisierte Grundsatzplanung von Mittelspannungsnetzen", Dissertation, 2006
-    .. [#] FGH e.V.: "Technischer Bericht 302: Ein Werkzeug zur Optimierung der Störungsbeseitigung
-        für Planung und Betrieb von Mittelspannungsnetzen", Tech. rep., 2008
+    .. [#] FGH e.V.: "Technischer Bericht 302: Ein Werkzeug zur Optimierung der Stoerungsbeseitigung
+        fuer Planung und Betrieb von Mittelspannungsnetzen", Tech. rep., 2008
 
     """
 

--- a/ding0/grid/mv_grid/util/util.py
+++ b/ding0/grid/mv_grid/util/util.py
@@ -35,22 +35,22 @@ def print_upper_triangular_matrix(matrix):
     # Print column header
     # Assumes first row contains all needed headers
     first = sorted(matrix.keys())[0]
-    print('\t', end=' ')
+    print('\t', end=" ")
     for i in matrix[first]:
-        print('{}\t'.format(i), end=' ')
+        print('{}\t'.format(i), end=" ")
     print()
 
     indent_count = 0
 
     for i in matrix:
         # Print line header
-        print('{}\t'.format(i), end=' ')
+        print('{}\t'.format(i), end=" ")
 
         if indent_count:
-            print('\t' * indent_count, end=' ')
+            print('\t' * indent_count, end=" ")
 
         for j in sorted(matrix[i]): # required because dict doesn't guarantee insertion order
-            print('{}\t'.format(matrix[i][j]), end=' ')
+            print('{}\t'.format(matrix[i][j]), end=" ")
 
         print()
 
@@ -73,7 +73,7 @@ def print_upper_triangular_matrix_as_complete(matrix):
             if a > b:
                 a, b = b, a
 
-            print(matrix[a][b], end=' ')
+            print(matrix[a][b], end=" ")
 
         print()
 

--- a/ding0_test_env.yml
+++ b/ding0_test_env.yml
@@ -9,7 +9,7 @@ dependencies:
     - seaborn
 
     # numerical processing packages
-    - pandas = 0.20.3
+    - pandas >= 0.20.3
 
     # graph theory processing
     - networkx >= 2.0
@@ -29,7 +29,7 @@ dependencies:
 
     # GIS dependencies have to come all from conda-forge
     - conda-forge::fiona
-    - conda-forge::pyproj = 1.9.5.1
+    - conda-forge::pyproj >= 1.9.5.1
     - conda-forge::pyshp
     - conda-forge::geopandas
     - conda-forge::geopy >= 1.11.0

--- a/ding0_test_env.yml
+++ b/ding0_test_env.yml
@@ -33,7 +33,7 @@ dependencies:
     - conda-forge::pyshp
     - conda-forge::geopandas
     - conda-forge::geopy >= 1.11.0
-    - conda-forge::shapely >= 1.5.12,
+    - conda-forge::shapely >= 1.5.12
     - conda-forge::libgdal
 
     - pip:

--- a/ding0_test_env.yml
+++ b/ding0_test_env.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
     # plotting packages
     - descartes
-    - matplotlib >= 1.5.3, <= 2.0.2
+    - matplotlib >= 1.5.3
     - seaborn
 
     # numerical processing packages
@@ -19,8 +19,8 @@ dependencies:
     - pytest
 
     # database packages
-    - sqlalchemy >= 1.0.11, <= 1.2.0
-    - geoalchemy2 >= 0.2.6, <=0.4.1
+    - sqlalchemy >= 1.0.11
+    - geoalchemy2 >= 0.2.6
     - psycopg2
 
     # other utilities
@@ -32,8 +32,8 @@ dependencies:
     - conda-forge::pyproj = 1.9.5.1
     - conda-forge::pyshp
     - conda-forge::geopandas
-    - conda-forge::geopy = 1.11.0
-    - conda-forge::shapely >= 1.5.12, <= 1.7
+    - conda-forge::geopy >= 1.11.0
+    - conda-forge::shapely >= 1.5.12,
     - conda-forge::libgdal
 
     - pip:

--- a/ding0_test_env.yml
+++ b/ding0_test_env.yml
@@ -1,0 +1,45 @@
+name: ding0_env
+channels:
+      - conda-forge
+      - defaults
+dependencies:
+    # plotting packages
+    - descartes
+    - matplotlib >= 1.5.3, <= 2.0.2
+    - seaborn
+
+    # numerical processing packages
+    - pandas = 0.20.3
+
+    # graph theory processing
+    - networkx >= 2.0
+
+    # testing packages
+    - unittest2
+    - pytest
+
+    # database packages
+    - sqlalchemy >= 1.0.11, <= 1.2.0
+    - geoalchemy2 >= 0.2.6, <=0.4.1
+    - psycopg2
+
+    # other utilities
+    - keyring
+
+
+    # GIS dependencies have to come all from conda-forge
+    - conda-forge::fiona
+    - conda-forge::pyproj = 1.9.5.1
+    - conda-forge::pyshp
+    - conda-forge::geopandas
+    - conda-forge::geopy = 1.11.0
+    - conda-forge::shapely >= 1.5.12, <= 1.7
+    - conda-forge::libgdal
+
+    - pip:
+        - demandlib
+        - egoio >= 0.4.5
+        - keyrings.alt
+        - oedialect
+        - pypsa == 0.11.0
+        - workalendar

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 networkx >= 2.0
 geopy >= 1.11.0
 pandas >= 0.20.3
-pyproj >= 1.9.5.1, <= 1.9.5.1
+pyproj >= 1.9.5.1
 sqlalchemy >= 1.0.11
 geoalchemy2 >= 0.2.6
 matplotlib  >= 1.5.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 networkx >= 2.0
-geopy >= 1.11.0, <= 1.11.0
-pandas >= 0.20.3, <= 0.20.3
+geopy >= 1.11.0
+pandas >= 0.20.3
 pyproj >= 1.9.5.1, <= 1.9.5.1
-sqlalchemy >= 1.0.11, <= 1.2.0
-geoalchemy2 >= 0.2.6, <= 0.4.1
-matplotlib  >= 1.5.3, <= 2.0.2
+sqlalchemy >= 1.0.11
+geoalchemy2 >= 0.2.6
+matplotlib  >= 1.5.3
 egoio >= 0.4.5
-shapely >= 1.5.12, <= 1.7
+shapely >= 1.5.12,
 pypsa >= 0.11.0, <= 0.11.0
 seaborn
 unittest2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ sqlalchemy >= 1.0.11
 geoalchemy2 >= 0.2.6
 matplotlib  >= 1.5.3
 egoio >= 0.4.5
-shapely >= 1.5.12,
+shapely >= 1.5.12
 pypsa >= 0.11.0, <= 0.11.0
 seaborn
 unittest2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ sqlalchemy >= 1.0.11, <= 1.2.0
 geoalchemy2 >= 0.2.6, <= 0.4.1
 matplotlib  >= 1.5.3, <= 2.0.2
 egoio >= 0.4.5
-shapely >= 1.5.12, <= 1.6.3
+shapely >= 1.5.12, <= 1.7
 pypsa >= 0.11.0, <= 0.11.0
 seaborn
 unittest2


### PR DESCRIPTION
**Not ready to merge**

The essential idea of this feature was to allow the use of conda within travis' CI. The .travis.yml file has been change appropirately but somehow during the installation of conda and the solving of the environment, it install Python 2.7 and not the expected Python version.

The current state of this is that: it is unknown why Python 2.7 is defaulted to eventhough there is an explicity python verision given at the beginning.

Hypothesis: There is a chance that if the version of python is not mentioned in the conda yml file which it uses to creat the environment, "conda doesn't take it seriously enough!" and defaults to using Python 2.7