### PR TITLE
Fix/modify mv routing test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
   - printf '%s\n' '[oedb]' 'dialect = oedialect' 'host = openenergy-platform.org' 'port = 443' 'database = oedb' 'username = Ding0_test_user' 'password = 659193bb5925d401943e4f77d4bac7479bcd9214'> $EGOIOCONFIGDIR/config.ini
   - cat $EGOIOCONFIGDIR/config.ini
   - pip install -r requirements.txt
+  - pip list
 # command to run tests
 script:
   - pytest -vv

--- a/ding0/tools/tools.py
+++ b/ding0/tools/tools.py
@@ -13,6 +13,10 @@ __url__        = "https://github.com/openego/ding0/blob/master/LICENSE"
 __author__     = "nesnoj, gplssm"
 
 
+from geopy import distance
+from shapely.geometry import Point, LineString, LinearRing, Polygon
+
+
 def merge_two_dicts(x, y):
     '''Given two dicts, merge them into a new dict as a shallow copy.
 
@@ -37,3 +41,109 @@ def merge_two_dicts(x, y):
     z = x.copy()
     z.update(y)
     return z
+
+
+def get_dest_point(source_point, distance_m, bearing_deg):
+    """
+    Get the WGS84 point / in the coordinate reference system
+    epsg 4326 at a distance (in meters) from
+    a source point in a given bearing (in degrees)
+    like the `bsdgame trek <https://en.wikipedia.org/wiki/Star_Trek_(1971_video_game)`_
+    on linux (0 degrees being North and clockwise is positive).
+
+    Parameters
+    ----------
+    source_point: :shapely:`Shapely Point object<points>`
+        The start point in WGS84 or epsg 4326 coordinates
+    distance_m: :obj:`float`
+        Distance of destination point from source in meters
+    bearing_deg: :obj:`float`
+        Bearing of destination point from source in degrees,
+        0 degrees being North and clockwise is positive
+        (like the `bsdgame trek <https://en.wikipedia.org/wiki/Star_Trek_(1971_video_game)`_
+        on linux).
+
+    Returns
+    -------
+    :shapely:`Shapely Point object<points>`
+        The point in WGS84 or epsg 4326 coordinates
+        at the destination which is distance meters
+        away from the source_point in the bearing provided
+
+    """
+    geopy_dest = (distance
+                  .distance(meters=distance_m)
+                  .destination((source_point.y,
+                                source_point.x),
+                               bearing_deg))
+    return Point(geopy_dest.longitude, geopy_dest.latitude)
+
+
+def get_cart_dest_point(source_point, east_meters, north_meters):
+    """
+    Get the WGS84 point / in the coordinate reference system
+    epsg 4326 at in given a cartesian form of input i.e.
+    providing the position of the destination point in relative
+    meters east and meters north from the source point.
+
+    If the source point is (0, 0) and you would like the coordinates
+    of a point that lies 5 meters north and 3 meters west of the source,
+    the bearing in degrees is hard to find on the fly. This function
+    allows the input as follows:
+
+    >>> get_cart_dest_point(source_point, -3, 5) # west is negative east
+
+    Parameters
+    ----------
+    source_point: :shapely:`Shapely Point object<points>`
+        The start point in WGS84 or epsg 4326 coordinates
+    east_meters: :obj:`float`
+        Meters to the east of source, negative number means west
+    north_meters: :obj:`float`
+        Meters to the north of source, negative number means south
+
+    Returns
+    -------
+    :shapely:`Shapely Point object<points>`
+        The point in WGS84 or epsg 4326 coordinates
+        at the destination which is north_meters north
+        of the source and east_meters east of source.
+    """
+    x_dist = abs(east_meters)
+    y_dist = abs(north_meters)
+    x_dir = (-90 if east_meters < 0
+             else 90)
+    y_dir = (180 if north_meters < 0
+             else 0)
+    intermediate_dest = get_dest_point(source_point, x_dist, x_dir)
+    return get_dest_point(intermediate_dest, y_dist, y_dir)
+
+
+def create_poly_from_source(source_point, left_m, right_m, up_m, down_m):
+    """
+    Create a rectangular polygon given a source point and the number of meters
+    away from the source point the edges have to be.
+
+    Parameters
+    ----------
+    source_point: :shapely:`Shapely Point object<points>`
+        The start point in WGS84 or epsg 4326 coordinates
+    left_m: :obj:`float`
+        The distance from the source at which the left edge should be.
+    right_m: :obj:`float`
+        The distance from the source at which the right edge should be.
+    up_m: :obj:`float`
+        The distance from the source at which the upper edge should be.
+    down_m: :obj:`float`
+        The distance from the source at which the lower edge should be.
+
+    Returns
+    -------
+    """
+    poly_points = [get_cart_dest_point(source_point, -1*left_m, -1*down_m),
+                   get_cart_dest_point(source_point, -1*left_m, up_m),
+                   get_cart_dest_point(source_point, right_m, up_m),
+                   get_cart_dest_point(source_point, right_m, -1*down_m),
+                   get_cart_dest_point(source_point, -1*left_m, -1*down_m)]
+    return Polygon(sum(map(list, (p.coords for p in poly_points)), []))
+

--- a/tests/core/network/test_grids.py
+++ b/tests/core/network/test_grids.py
@@ -963,6 +963,22 @@ class TestMVGridDing0(object):
 
         return network, mv_grid, source
 
+    def test_local_routing(self, minimal_unrouted_grid):
+        """
+        Rigours test to the function :meth:`~.core.network.grids.MVGridDing0.routing`
+        """
+        nd, mv_grid, source = minimal_unrouted_grid()
+
+        graph = mv_grid._graph
+
+        # pre-routing asserts
+
+        nd.mv_routing()
+
+        # post-routing asserts
+        # check that the connections are between the expected
+        # load areas
+
     def test_routing(self, oedb_session):
         """
         Using the grid district 460 as an example, the properties of the

--- a/tests/core/network/test_grids.py
+++ b/tests/core/network/test_grids.py
@@ -1042,7 +1042,7 @@ class TestMVGridDing0(object):
             (lv_stations[10], mv_cable_distributors[2]),
         ]
 
-        assert set(expected_edges_list) == set(graph.edges)
+        assert set(expected_edges_list) == set(graph.edges())
 
         # check graph attributes
         assert len(list(graph.nodes())) == 35

--- a/tests/core/network/test_grids.py
+++ b/tests/core/network/test_grids.py
@@ -970,7 +970,7 @@ class TestMVGridDing0(object):
         """
         Rigorous test to the function :meth:`~.core.network.grids.MVGridDing0.routing`
         """
-        nd, mv_grid, lv_stations = minimal_unrouted_grid()
+        nd, mv_grid, lv_stations = minimal_unrouted_grid
 
         graph = mv_grid._graph
 

--- a/tests/core/network/test_grids.py
+++ b/tests/core/network/test_grids.py
@@ -976,7 +976,6 @@ class TestMVGridDing0(object):
 
         # pre-routing asserts
         # check the grid_district
-        assert mv_grid.grid_district.id_db == 1000
         assert len(list(mv_grid.grid_district.lv_load_areas())) == 19
         assert len(list(mv_grid.grid_district.lv_load_area_groups())) == 0
         assert mv_grid.grid_district.peak_load == pytest.approx(


### PR DESCRIPTION
**Not Ready to merge**.

This was an improvement to the existing mv grids' routing test. The existing test case used the example grid and draws all the information that it needs from oep. The test case that is written here creates an artificial ding0 grid, to check that each and every connection made during the routing for both the connection points, the positioning of the ciricutbreaker and the thickness of the lines.

Current state of this branch is:
The pytest fixture creating the test grid is complete. The test case's assert to check each and every edge created seems to pass and fail at random. The randomness is induced by the naming /order of the mv circuitbreakers that are created during routing. Once the assert statement is crafted such that the order of the circuit-breakers can be deterministically obtained, this branch should work properly.
