### PR TITLE
Fix/#300 vde norm critical nodes

### DIFF
--- a/ding0/flexopt/check_tech_constraints.py
+++ b/ding0/flexopt/check_tech_constraints.py
@@ -435,7 +435,7 @@ def get_critical_voltage_at_nodes(grid):
             grid_conn_points.append(node)
 
     # voltage at substation bus bar
-    r_mv_grid, x_mv_grid = get_mv_impedance_at_voltage_level(grid, grid.v_level/1000)
+    r_mv_grid, x_mv_grid = get_mv_impedance_at_voltage_level(grid, grid.v_level/1e3)
 
     r_trafo = sum([tr.r for tr in grid._station._transformers])
     x_trafo = sum([tr.x for tr in grid._station._transformers])
@@ -775,7 +775,7 @@ def get_voltage_at_bus_bar(grid, tree):
     """
 
     # voltage at substation bus bar
-    r_mv_grid, x_mv_grid = get_mv_impedance_at_voltage_level(grid, grid.v_level/1000)
+    r_mv_grid, x_mv_grid = get_mv_impedance_at_voltage_level(grid, grid.v_level/1e3)
 
     r_trafo = sum([tr.r for tr in grid._station._transformers])
     x_trafo = sum([tr.x for tr in grid._station._transformers])

--- a/ding0/flexopt/check_tech_constraints.py
+++ b/ding0/flexopt/check_tech_constraints.py
@@ -435,7 +435,7 @@ def get_critical_voltage_at_nodes(grid):
             grid_conn_points.append(node)
 
     # voltage at substation bus bar
-    r_mv_grid, x_mv_grid = get_mv_impedance(grid)
+    r_mv_grid, x_mv_grid = get_mv_impedance_at_voltage_level(grid, grid.v_level/1000)
 
     r_trafo = sum([tr.r for tr in grid._station._transformers])
     x_trafo = sum([tr.x for tr in grid._station._transformers])
@@ -663,13 +663,15 @@ def get_voltage_delta_branch(grid, tree, node, r_preceeding, x_preceeding):
     return [voltage_delta_load, voltage_delta_gen, r, x]
 
 
-def get_mv_impedance(grid):
+def get_mv_impedance_at_voltage_level(grid, voltage_level):
     """
     Determine MV grid impedance (resistance and reactance separately)
 
     Parameters
     ----------
     grid : :class:`~.ding0.core.network.grids.LVGridDing0`
+    voltage_level: float
+        voltage level to which impedance is rescaled (normally 0.4 kV for LV)
 
     Returns
     -------
@@ -685,8 +687,10 @@ def get_mv_impedance(grid):
                      for e in edges])
     x_mv_grid = sum([e[2]['branch'].type['L'] / 1e3 * omega * e[2][
         'branch'].length / 1e3 for e in edges])
-
-    return [r_mv_grid, x_mv_grid]
+    # rescale to voltage level
+    r_mv_grid_vl = r_mv_grid * (voltage_level / mv_grid.v_level) ** 2
+    x_mv_grid_vl = x_mv_grid * (voltage_level / mv_grid.v_level) ** 2
+    return [r_mv_grid_vl, x_mv_grid_vl]
 
 
 def voltage_delta_stub(grid, tree, main_branch_node, stub_node, r_preceeding,
@@ -771,7 +775,7 @@ def get_voltage_at_bus_bar(grid, tree):
     """
 
     # voltage at substation bus bar
-    r_mv_grid, x_mv_grid = get_mv_impedance(grid)
+    r_mv_grid, x_mv_grid = get_mv_impedance_at_voltage_level(grid, grid.v_level/1000)
 
     r_trafo = sum([tr.r for tr in grid._station._transformers])
     x_trafo = sum([tr.x for tr in grid._station._transformers])

--- a/ding0/flexopt/check_tech_constraints.py
+++ b/ding0/flexopt/check_tech_constraints.py
@@ -410,8 +410,6 @@ def get_critical_voltage_at_nodes(grid):
     v_delta_tolerable_lc = cfg_ding0.get('assumptions',
                                       'lv_max_v_level_lc_diff_normal')
 
-    omega = 2 * math.pi * 50
-
     crit_nodes = []
 
     # get list of nodes of main branch in right order
@@ -434,14 +432,7 @@ def get_critical_voltage_at_nodes(grid):
                for successor in successors)):
             grid_conn_points.append(node)
 
-    # voltage at substation bus bar
-    r_mv_grid, x_mv_grid = get_mv_impedance_at_voltage_level(grid, grid.v_level/1e3)
-
-    r_trafo = sum([tr.r for tr in grid._station._transformers])
-    x_trafo = sum([tr.x for tr in grid._station._transformers])
-
-    v_delta_load_case_bus_bar, \
-    v_delta_gen_case_bus_bar = get_voltage_at_bus_bar(grid, tree)
+    v_delta_load_case_bus_bar, v_delta_gen_case_bus_bar  = get_voltage_at_bus_bar(grid, tree)
 
     if (abs(v_delta_gen_case_bus_bar) > v_delta_tolerable_fc
         or abs(v_delta_load_case_bus_bar) > v_delta_tolerable_lc):
@@ -455,70 +446,30 @@ def get_critical_voltage_at_nodes(grid):
     for first_node in [b for b in tree.successors(grid._station)
                    if b in main_branch]:
 
-        # cumulative resistance/reactance at bus bar
-        r = r_mv_grid + r_trafo
-        x = x_mv_grid + x_trafo
-
-        # roughly estimate transverse voltage drop
-        stub_node = [_ for _ in list(tree.successors(first_node)) if
-                     _ not in main_branch][0]
-        v_delta_load_stub, v_delta_gen_stub = voltage_delta_stub(
-            grid,
-            tree,
-            first_node,
-            stub_node,
-            r,
-            x)
-
+        # initiate loop over feeder
+        successor = first_node
         # cumulative voltage drop/increase at substation bus bar
         v_delta_load_cum = v_delta_load_case_bus_bar
         v_delta_gen_cum = v_delta_gen_case_bus_bar
 
-        # calculate voltage at first node of branch
-        voltage_delta_load, voltage_delta_gen, r, x = \
-            get_voltage_delta_branch(grid, tree, first_node, r, x)
-
-        v_delta_load_cum += voltage_delta_load
-        v_delta_gen_cum += voltage_delta_gen
-
-        if (abs(v_delta_gen_cum) > (v_delta_tolerable_fc - v_delta_gen_stub)
-            or abs(v_delta_load_cum) > (v_delta_tolerable_lc - v_delta_load_stub)):
-            crit_nodes.append({'node': first_node,
-                               'v_diff': [v_delta_load_cum,
-                                          v_delta_gen_cum]})
-            crit_nodes.append({'node': stub_node,
-                               'v_diff': [
-                                   v_delta_load_cum + v_delta_load_stub,
-                                   v_delta_gen_cum + v_delta_gen_stub]})
-
-        # get next neighboring nodes down the tree
-        successor = [x for x in tree.successors(first_node)
-                      if x in main_branch]
-        if successor:
-            successor = successor[0] # simply unpack
-
         # successively determine voltage levels for succeeding nodes
         while successor:
-            voltage_delta_load, voltage_delta_gen, r, x = \
-                get_voltage_delta_branch(grid, tree, successor, r, x)
-
+            # calculate voltage drop over preceding line
+            voltage_delta_load, voltage_delta_gen  = get_delta_voltage_preceding_line(grid, tree, successor)
+            # add voltage drop over preceding line
             v_delta_load_cum += voltage_delta_load
             v_delta_gen_cum += voltage_delta_gen
 
             # roughly estimate transverse voltage drop
             stub_node = [_ for _ in tree.successors(successor) if
                          _ not in main_branch][0]
-            v_delta_load_stub, v_delta_gen_stub = voltage_delta_stub(
-                grid,
-                tree,
-                successor,
-                stub_node,
-                r,
-                x)
+            v_delta_load_stub, v_delta_gen_stub  = get_delta_voltage_preceding_line(grid, tree, stub_node)
 
-            if (abs(v_delta_gen_cum) > (v_delta_tolerable_fc - v_delta_gen_stub)
+            # check if voltage drop at node exceeds tolerable voltage drop
+            if (abs(v_delta_gen_cum) > (v_delta_tolerable_fc)
                 or abs(v_delta_load_cum) > (
-                            v_delta_tolerable_lc - v_delta_load_stub)):
+                            v_delta_tolerable_lc)):
+                # add node and successing stub node to critical nodes
                 crit_nodes.append({'node': successor,
                                    'v_diff': [v_delta_load_cum,
                                               v_delta_gen_cum]})
@@ -526,6 +477,15 @@ def get_critical_voltage_at_nodes(grid):
                                    'v_diff': [
                                        v_delta_load_cum + v_delta_load_stub,
                                        v_delta_gen_cum + v_delta_gen_stub]})
+            # check if voltage drop at stub node exceeds tolerable voltage drop
+            elif ((abs(v_delta_gen_cum + v_delta_gen_stub) > v_delta_tolerable_fc)
+                or (abs(v_delta_load_cum + v_delta_load_stub) > v_delta_tolerable_lc)):
+                # add stub node to critical nodes
+                crit_nodes.append({'node': stub_node,
+                                   'v_diff': [
+                                       v_delta_load_cum + v_delta_load_stub,
+                                       v_delta_gen_cum + v_delta_gen_stub]})
+
 
             successor = [_ for _ in tree.successors(successor)
                          if _ in main_branch]
@@ -535,50 +495,116 @@ def get_critical_voltage_at_nodes(grid):
     return crit_nodes
 
 
-def voltage_delta_vde(v_nom, s_max, r, x, cos_phi):
+def get_voltage_at_bus_bar(grid, tree):
     """
-    Estimate voltrage drop/increase
+        Determine voltage level at bus bar of MV-LV substation
 
-    The VDE [#]_ proposes a simplified method to estimate voltage drop or
-    increase in radial grids.
+        Parameters
+        ----------
+        grid : :class:`~.ding0.core.network.grids.LVGridDing0`
+            Ding0 grid object
+        tree : :networkx:`NetworkX Graph Obj< >`
+            Tree of grid topology:
+
+        Returns
+        -------
+        :obj:`list`
+            Voltage at bus bar. First item refers to load case, second item refers
+            to voltage in feedin (generation) case
+        """
+    # impedance of mv grid and transformer
+    r_mv_grid, x_mv_grid = get_mv_impedance_at_voltage_level(grid, grid.v_level / 1e3)
+    r_trafo = sum([tr.r for tr in grid._station._transformers]) # ToDo: change calculation of transformer impedance according to branch transformer data
+    x_trafo = sum([tr.x for tr in grid._station._transformers])
+    # cumulative resistance/reactance at bus bar
+    r_busbar = r_mv_grid + r_trafo
+    x_busbar = x_mv_grid + x_trafo
+    # get voltage drop at substation bus bar
+    v_delta_load_case_bus_bar, \
+    v_delta_gen_case_bus_bar = get_voltage_delta_branch(tree, grid._station, r_busbar, x_busbar)
+    return v_delta_load_case_bus_bar, v_delta_gen_case_bus_bar
+
+
+def get_delta_voltage_preceding_line(grid, tree, node):
+    """
+    Parameters
+    ----------
+    grid : :class:`~.ding0.core.network.grids.LVGridDing0`
+        Ding0 grid object
+    tree: :networkx:`NetworkX Graph Obj< >`
+        Tree of grid topology
+    node: graph node
+        Node at end of line
+    Return
+    ------
+    :any:`float`
+        Voltage drop over preceding line of node
+    """
+
+    # get impedance of preceding line
+    omega = 2 * math.pi * 50  # ToDo: change 50 to meta frequency when merged to branch with introduction of this value
+
+    # choose preceding branch
+    branch = [_ for _ in grid.graph_branches_from_node(node) if
+              _[0] in list(tree.predecessors(node))][0][1]
+
+    # calculate impedance of preceding branch
+    r_line = (branch['branch'].type['R'] * branch['branch'].length/1e3)
+    x_line = (branch['branch'].type['L'] / 1e3 * omega *
+         branch['branch'].length/1e3)
+
+    # get voltage drop over preceeding line
+    voltage_delta_load, voltage_delta_gen = \
+        get_voltage_delta_branch(tree, node, r_line, x_line)
+
+    return voltage_delta_load, voltage_delta_gen
+
+
+def get_voltage_delta_branch(tree, node, r, x):
+    """
+    Determine voltage for a branch with impedance r + jx
 
     Parameters
     ----------
-    v_nom : :obj:`int`
-        Nominal voltage
-    s_max : :obj:`float`
-        Apparent power
-    r : :obj:`float`
-        Short-circuit resistance from node to HV/MV substation (in ohm)
-    x : :obj:`float`
-        Short-circuit reactance from node to HV/MV substation (in ohm). Must
-        be a signed number indicating (+) inductive reactive consumer (load
-        case) or (-) inductive reactive supplier (generation case)
-    cos_phi : :obj:`float`
-        The cosine phi of the connected generator or load that induces the
-        voltage change
+    tree : :networkx:`NetworkX Graph Obj< >`
+        Tree of grid topology
+    node : graph node
+        Node to determine voltage level at
+    r : float
+        Resistance of preceeding branch
+    x : float
+        Reactance of preceeding branch
 
-    Returns
-    -------
-    :obj:`float`
-        Voltage drop or increase
-        
-    References
-    ----------
-    .. [#] VDE Anwenderrichtlinie: Erzeugungsanlagen am Niederspannungsnetz –
-        Technische Mindestanforderungen für Anschluss und Parallelbetrieb von
-        Erzeugungsanlagen am Niederspannungsnetz, 2011
-
+    Return
+    ------
+    :any:`float`
+        Delta voltage for branch
     """
-    delta_v = (s_max * (
-        r * cos_phi - x * math.sin(math.acos(cos_phi)))) / v_nom ** 2
-    return delta_v
+    cos_phi_load = cfg_ding0.get('assumptions', 'cos_phi_load')
+    cos_phi_feedin = cfg_ding0.get('assumptions', 'cos_phi_gen')
+    cos_phi_load_mode = cfg_ding0.get('assumptions', 'cos_phi_load_mode')
+    cos_phi_feedin_mode = cfg_ding0.get('assumptions', 'cos_phi_gen_mode') #ToDo: Check if this is true. Why would generator run in a way that aggravates voltage issues?
+    v_nom = cfg_ding0.get('assumptions', 'lv_nominal_voltage')
+
+    # get apparent power for load and generation case
+    peak_load, gen_capacity = get_cumulated_conn_gen_load(tree, node)
+    s_max_load = peak_load/cos_phi_load
+    s_max_feedin = gen_capacity/cos_phi_feedin
+
+    # determine voltage increase/ drop a node
+    x_sign_load = q_sign(cos_phi_load_mode, 'load')
+    voltage_delta_load = voltage_delta_vde(v_nom, s_max_load, r, x_sign_load * x,
+                                           cos_phi_load)
+    x_sign_gen = q_sign(cos_phi_feedin_mode, 'load')
+    voltage_delta_gen = voltage_delta_vde(v_nom, s_max_feedin, r, x_sign_gen * x,
+                                          cos_phi_feedin)
+
+    return [voltage_delta_load, voltage_delta_gen]
 
 
-def get_house_conn_gen_load(graph, node):
+def get_cumulated_conn_gen_load(graph, node):
     """
-    Get generation capacity/ peak load of neighboring house connected to main
-    branch
+    Get generation capacity/ peak load of all descending nodes
 
     Parameters
     ----------
@@ -591,76 +617,19 @@ def get_house_conn_gen_load(graph, node):
     -------
     :obj:`list`
         A list containing two items
-        
-        # peak load of connected house branch
-        # generation capacity of connected generators
+
+        # cumulated peak load of connected loads at descending nodes of node
+        # cumulated generation capacity of connected generators at descending nodes of node
     """
-    generation = 0
-    peak_load = 0
 
-    for cus_1 in graph.successors(node):
-        for cus_2 in graph.successors(cus_1):
-            if not isinstance(cus_2, list):
-                cus_2 = [cus_2]
-            generation += sum([gen.capacity for gen in cus_2
-                          if isinstance(gen, GeneratorDing0)])
-            peak_load += sum([load.peak_load for load in cus_2
-                          if isinstance(load, LVLoadDing0)])
-
+    # loads and generators connected to descending nodes
+    peak_load = sum(
+        [node.peak_load for node in nx.descendants(graph, node)
+         if isinstance(node, LVLoadDing0)])
+    generation = sum(
+        [node.capacity for node in nx.descendants(graph, node)
+         if isinstance(node, GeneratorDing0)])
     return [peak_load, generation]
-
-
-def get_voltage_delta_branch(grid, tree, node, r_preceeding, x_preceeding):
-    """
-    Determine voltage for a preceeding branch (edge) of node
-
-    Parameters
-    ----------
-    grid : :class:`~.ding0.core.network.grids.LVGridDing0`
-        Ding0 grid object
-    tree : :networkx:`NetworkX Graph Obj< >`
-        Tree of grid topology
-    node : graph node
-        Node to determine voltage level at
-    r_preceeding : float
-        Resitance of preceeding grid
-    x_preceeding : float
-        Reactance of preceeding grid
-
-    Return
-    ------
-    :any:`float`
-        Delta voltage for node
-    """
-    cos_phi_load = cfg_ding0.get('assumptions', 'cos_phi_load')
-    cos_phi_load_mode = cfg_ding0.get('assumptions', 'cos_phi_load_mode')
-    cos_phi_feedin = cfg_ding0.get('assumptions', 'cos_phi_gen')
-    cos_phi_feedin_mode = cfg_ding0.get('assumptions', 'cos_phi_gen_mode')
-    v_nom = cfg_ding0.get('assumptions', 'lv_nominal_voltage')
-    omega = 2 * math.pi * 50
-
-    # add resitance/ reactance to preceeding
-    in_edge = [_ for _ in grid.graph_branches_from_node(node) if
-               _[0] in list(tree.predecessors(node))][0][1]
-    r = r_preceeding + (in_edge['branch'].type['R'] *
-                     in_edge['branch'].length)
-    x = x_preceeding + (in_edge['branch'].type['L'] / 1e3 * omega *
-                     in_edge['branch'].length)
-
-    # get apparent power for load and generation case
-    peak_load, gen_capacity = get_house_conn_gen_load(tree, node)
-    s_max_load = peak_load / cos_phi_load
-    s_max_feedin = gen_capacity / cos_phi_feedin
-
-    # determine voltage increase/ drop a node
-    x_sign_load = q_sign(cos_phi_load_mode, 'load')
-    voltage_delta_load = voltage_delta_vde(v_nom, s_max_load, r, x_sign_load * x,
-                                           cos_phi_load)
-    x_sign_gen = q_sign(cos_phi_feedin_mode, 'load')
-    voltage_delta_gen = voltage_delta_vde(v_nom, s_max_feedin, r, x_sign_gen * x,
-                                          cos_phi_feedin)
-
-    return [voltage_delta_load, voltage_delta_gen, r, x]
 
 
 def get_mv_impedance_at_voltage_level(grid, voltage_level):
@@ -693,118 +662,41 @@ def get_mv_impedance_at_voltage_level(grid, voltage_level):
     return [r_mv_grid_vl, x_mv_grid_vl]
 
 
-def voltage_delta_stub(grid, tree, main_branch_node, stub_node, r_preceeding,
-                       x_preceedig):
+def voltage_delta_vde(v_nom, s_max, r, x, cos_phi):
     """
-    Determine voltage for stub branches
+    Estimate voltrage drop/increase
+
+    The VDE [#]_ proposes a simplified method to estimate voltage drop or
+    increase in radial grids.
 
     Parameters
     ----------
-    grid : :class:`~.ding0.core.network.grids.LVGridDing0`
-        Ding0 grid object
-    tree : :networkx:`NetworkX Graph Obj< >`
-        Tree of grid topology
-    main_branch_node : graph node
-        Node of main branch that stub branch node in connected to
-    main_branch : dict
-        Nodes of main branch
-    r_preceeding : float
-        Resitance of preceeding grid
-    x_preceeding : float
-        Reactance of preceeding grid
-
-    Return
-    ------
-    :any:`float`
-        Delta voltage for node
-    """
-    cos_phi_load = cfg_ding0.get('assumptions', 'cos_phi_load')
-    cos_phi_load_mode = cfg_ding0.get('assumptions', 'cos_phi_load_mode')
-    cos_phi_feedin = cfg_ding0.get('assumptions', 'cos_phi_gen')
-    cos_phi_feedin_mode = cfg_ding0.get('assumptions', 'cos_phi_gen_mode')
-    v_nom = cfg_ding0.get('assumptions', 'lv_nominal_voltage')
-    omega = 2 * math.pi * 50
-
-    stub_branch = [_ for _ in grid.graph_branches_from_node(main_branch_node) if
-                   _[0] == stub_node][0][1]
-    r_stub = stub_branch['branch'].type['R'] * stub_branch[
-        'branch'].length / 1e3
-    x_stub = stub_branch['branch'].type['L'] / 1e3 * omega * \
-             stub_branch['branch'].length / 1e3
-    s_max_gen = [_.capacity / cos_phi_feedin
-                 for _ in tree.successors(stub_node)
-                 if isinstance(_, GeneratorDing0)]
-    if s_max_gen:
-        s_max_gen = s_max_gen[0]
-        x_sign_gen = q_sign(cos_phi_feedin_mode, 'load')
-        v_delta_stub_gen = voltage_delta_vde(v_nom, s_max_gen, r_stub + r_preceeding,
-                                             x_sign_gen * (x_stub + x_preceedig), cos_phi_feedin)
-    else:
-        v_delta_stub_gen = 0
-
-    s_max_load = [_.peak_load / cos_phi_load
-                  for _ in tree.successors(stub_node)
-                  if isinstance(_, LVLoadDing0)]
-    if s_max_load:
-        s_max_load = s_max_load[0]
-        x_sign_load = q_sign(cos_phi_load_mode, 'load')
-        v_delta_stub_load = voltage_delta_vde(v_nom, s_max_load, r_stub + r_preceeding,
-                                              x_sign_load * (x_stub + x_preceedig), cos_phi_load)
-    else:
-        v_delta_stub_load = 0
-
-    return [v_delta_stub_load, v_delta_stub_gen]
-
-
-def get_voltage_at_bus_bar(grid, tree):
-    """
-    Determine voltage level at bus bar of MV-LV substation
-
-    Parameters
-    ----------
-    grid : :class:`~.ding0.core.network.grids.LVGridDing0`
-        Ding0 grid object
-    tree : :networkx:`NetworkX Graph Obj< >`
-        Tree of grid topology:
+    v_nom : :obj:`int`
+        Nominal voltage
+    s_max : :obj:`float`
+        Apparent power
+    r : :obj:`float`
+        Short-circuit resistance from node to HV/MV substation (in ohm)
+    x : :obj:`float`
+        Short-circuit reactance from node to HV/MV substation (in ohm). Must
+        be a signed number indicating (+) inductive reactive consumer (load
+        case) or (-) inductive reactive supplier (generation case)
+    cos_phi : :obj:`float`
+        The cosine phi of the connected generator or load that induces the
+        voltage change
 
     Returns
     -------
-    :obj:`list`
-        Voltage at bus bar. First item refers to load case, second item refers
-        to voltage in feedin (generation) case
+    :obj:`float`
+        Voltage drop or increase
+
+    References
+    ----------
+    .. [#] VDE Anwenderrichtlinie: Erzeugungsanlagen am Niederspannungsnetz –
+        Technische Mindestanforderungen für Anschluss und Parallelbetrieb von
+        Erzeugungsanlagen am Niederspannungsnetz, 2011
+
     """
-
-    # voltage at substation bus bar
-    r_mv_grid, x_mv_grid = get_mv_impedance_at_voltage_level(grid, grid.v_level/1e3)
-
-    r_trafo = sum([tr.r for tr in grid._station._transformers])
-    x_trafo = sum([tr.x for tr in grid._station._transformers])
-
-    cos_phi_load = cfg_ding0.get('assumptions', 'cos_phi_load')
-    cos_phi_load_mode = cfg_ding0.get('assumptions', 'cos_phi_load_mode')
-    cos_phi_feedin = cfg_ding0.get('assumptions', 'cos_phi_gen')
-    cos_phi_feedin_mode = cfg_ding0.get('assumptions', 'cos_phi_gen_mode')
-    v_nom = cfg_ding0.get('assumptions', 'lv_nominal_voltage')
-
-    # loads and generators connected to bus bar
-    bus_bar_load = sum(
-        [node.peak_load for node in tree.successors(grid._station)
-         if isinstance(node, LVLoadDing0)]) / cos_phi_load
-    bus_bar_generation = sum(
-        [node.capacity for node in tree.successors(grid._station)
-         if isinstance(node, GeneratorDing0)]) / cos_phi_feedin
-
-    x_sign_load = q_sign(cos_phi_load_mode, 'load')
-    v_delta_load_case_bus_bar = voltage_delta_vde(v_nom,
-                                                  bus_bar_load,
-                                                  (r_mv_grid + r_trafo),
-                                                  x_sign_load * (x_mv_grid + x_trafo),
-                                                  cos_phi_load)
-    x_sign_gen = q_sign(cos_phi_feedin_mode, 'load')
-    v_delta_gen_case_bus_bar = voltage_delta_vde(v_nom,
-                                                 bus_bar_generation,
-                                                 (r_mv_grid + r_trafo),
-                                                 x_sign_gen * (x_mv_grid + x_trafo),
-                                                 cos_phi_feedin)
-
-    return v_delta_load_case_bus_bar, v_delta_gen_case_bus_bar
+    delta_v = (s_max * 1e3 * (
+            r * cos_phi - x * math.sin(math.acos(cos_phi)))) / v_nom ** 2
+    return delta_v

--- a/ding0/flexopt/reinforce_grid.py
+++ b/ding0/flexopt/reinforce_grid.py
@@ -108,7 +108,7 @@ def reinforce_grid(grid, mode):
         # get overloaded branches
         # overloading issues
         critical_branches, critical_stations = get_critical_line_loading(grid)
-
+        no_crit_branches = len(critical_branches)
 
         # reinforce overloaded lines by increasing size
         unresolved = reinforce_lv_branches_overloading(grid, critical_branches)
@@ -116,7 +116,7 @@ def reinforce_grid(grid, mode):
             "Out of {crit_branches} with overloading {unresolved} remain "
             "with unresolved issues due to line overloading. "
             "LV grid: {grid}".format(
-                crit_branches=len(critical_branches),
+                crit_branches=no_crit_branches,
                 unresolved=len(unresolved),
                 grid=grid))
 

--- a/ding0/flexopt/reinforce_grid.py
+++ b/ding0/flexopt/reinforce_grid.py
@@ -125,6 +125,13 @@ def reinforce_grid(grid, mode):
 
         # get node with over-voltage
         crit_nodes = get_critical_voltage_at_nodes(grid) #over-voltage issues
+        # reinforcement of LV stations on voltage issues
+        crit_stations_voltage = [_ for _ in crit_nodes  # Is this ever reached?
+                                 if isinstance(_['node'], LVStationDing0)]
+        if crit_stations_voltage:
+            extend_substation_voltage(crit_stations_voltage, grid_level='LV')
+            for station in crit_stations_voltage:
+                crit_nodes.remove(station)
 
         crit_nodes_count_prev_step = len(crit_nodes)
 
@@ -159,9 +166,5 @@ def reinforce_grid(grid, mode):
             logger.info('==> All voltage issues in {mode} grid could be '
                         'solved using reinforcement.'.format(mode=mode))
 
-        # reinforcement of LV stations on voltage issues
-        crit_stations_voltage = [_ for _ in crit_nodes
-                        if isinstance(_['node'], LVStationDing0)]
-        if crit_stations_voltage:
-            extend_substation_voltage(crit_stations_voltage, grid_level='LV')
+
 

--- a/ding0/flexopt/reinforce_measures.py
+++ b/ding0/flexopt/reinforce_measures.py
@@ -225,7 +225,7 @@ def extend_substation(grid, critical_stations, grid_level):
                 lv_transformer = TransformerDing0(
                     grid=grid,
                     id_db=id,
-                    v_level=0.4,
+                    v_level=0.4, #ToDo: replace hard coded number by meta v_nom
                     s_max_longterm=trafo_type['S_nom'],
                     r=trafo_type['R'],
                     x=trafo_type['X'])
@@ -294,7 +294,7 @@ def extend_substation_voltage(crit_stations, grid_level='LV'):
                 lv_transformer = TransformerDing0(
                     grid=grid,
                     id_db=id,
-                    v_level=0.4,
+                    v_level=0.4, #ToDo: replace hardcoded number by meta v_nom
                     s_max_longterm=trafo_min_size['S_nom'],
                     r=trafo_min_size['R'],
                     x=trafo_min_size['X'])
@@ -316,6 +316,10 @@ def extend_substation_voltage(crit_stations, grid_level='LV'):
                                "extension is halted.".format(
                     station=station['node']))
                 break
+
+        if (v_delta[0] > v_delta_initially_lc) or (v_delta[1] > v_delta_initially_fc):
+            raise Exception ('Voltage issue at substation {} could not be resolved. LV grid reinforcement'
+                             'can therefore never result in correct grids. Check MV grid for line reinforcement.'.format(station))
 
 
 def new_substation(grid):

--- a/ding0/flexopt/reinforce_measures.py
+++ b/ding0/flexopt/reinforce_measures.py
@@ -358,8 +358,8 @@ def reinforce_lv_branches_overloading(grid, crit_branches):
 
     # resolve overloading issues for each branch segment
     for branch in crit_branches:
-        I_max_branch_load = branch['s_max'][0]
-        I_max_branch_gen = branch['s_max'][1]
+        I_max_branch_load = branch['s_max'][0]/(3**0.5 * grid.v_level / 1e3)
+        I_max_branch_gen = branch['s_max'][1]/(3**0.5 * grid.v_level / 1e3)
         I_max_branch = max([I_max_branch_load, I_max_branch_gen])
 
         suitable_cables = cables[(cables['I_max_th'] * cable_lf)

--- a/ding0/flexopt/reinforce_measures.py
+++ b/ding0/flexopt/reinforce_measures.py
@@ -317,7 +317,7 @@ def extend_substation_voltage(crit_stations, grid_level='LV'):
                     station=station['node']))
                 break
 
-        if (v_delta[0] > v_delta_initially_lc) or (v_delta[1] > v_delta_initially_fc):
+        if (v_delta[0] > v_diff_max_lc) or (v_delta[1] > v_diff_max_fc):
             raise Exception ('Voltage issue at substation {} could not be resolved. LV grid reinforcement'
                              'can therefore never result in correct grids. Check MV grid for line reinforcement.'.format(station))
 

--- a/ding0/tools/results.py
+++ b/ding0/tools/results.py
@@ -733,8 +733,8 @@ def calculate_mvgd_stats(nw):
             elif isinstance(node, CircuitBreakerDing0):
                 cb_count += 1
 
-            max_mv_path = max(max_mv_path, mv_path_length / 1000)
-            max_mvlv_path = max(max_mvlv_path, mvlv_path_length / 1000)
+            max_mv_path = max(max_mv_path, mv_path_length / 1e3)
+            max_mvlv_path = max(max_mvlv_path, mvlv_path_length / 1e3)
 
         other_nodes_dict[district.mv_grid.id_db] = {
             'CD_count': cd_count,

--- a/doc/whatsnew/v0-1-11.rst
+++ b/doc/whatsnew/v0-1-11.rst
@@ -18,3 +18,8 @@ Changes
   `#266 <https://github.com/openego/ding0/issues/266>`_,
   see also `PR #271 <https://github.com/openego/ding0/pull/271>`_.
 
+* Identification of critical nodes by VDE norm AR 4105 fixed. All power flows behind
+  node are taken into account now.
+
+  Should solve `#300 <https://github.com/openego/ding0/issues/300>`_.
+

--- a/tests/flexopt/test_check_tech_constraints.py
+++ b/tests/flexopt/test_check_tech_constraints.py
@@ -39,8 +39,8 @@ def test_voltage_delta_vde():
         Erzeugungsanlagen am Niederspannungsnetz, 2011
     """
 
-    v_nom = 1  # kV
-    s_max = 1  # MVA/kVA
+    v_nom = 1000  # V
+    s_max = 1  # kVA
     r = 1  # Ohms
     x = 1  # Ohms
     cos_phi = 1/sqrt(2)  # no unit i.e. 1/ sqrt(2) => angle is 45 degrees
@@ -51,7 +51,7 @@ def test_voltage_delta_vde():
                                                 r,
                                                 x_sign_inductive * x,
                                                 cos_phi)
-    voltage_delta_inductive_expected = sqrt(2)
+    voltage_delta_inductive_expected = sqrt(2)/1000
     voltage_delta_capacitive = voltage_delta_vde(v_nom,
                                                  s_max,
                                                  r,


### PR DESCRIPTION
Should fix #300 
Calculation of voltages at nodes changed. Should comply with VDE norm now. All power flows lying behind the node are taken into account now. Fixes of errors due to different voltage levels and units included.