### PR TITLE
extend methods: get_fully_conn_graph / connect_graph_components

### DIFF
--- a/ding0/config/config_lv_grids_osm.py
+++ b/ding0/config/config_lv_grids_osm.py
@@ -40,6 +40,7 @@ def get_config_osm(key):
         'ons_dist_threshold' : 1500,
         'buffer_distance' : [5, 25, 50, 100],
         'unconn_nodes_ratio' : 0.02,
+        'major_ccs_ratio_threshold' : .30,
         'get_fully_conn_graph_number_max_it' : 4,
         'diversity_factor_not_residential' : 0.6,
     }


### PR DESCRIPTION
- method `connect_graph_components` has been extended by a function to only connect major (larger) graph components with each other by using synthetic edges
- this method is used in `get_fully_conn_graph` to firstly connect major graph components of max. buffered polygon before finding the min. necessary connected street graph
- the improvement now regards the connection of large isolated graph components before finding the final street graph